### PR TITLE
Moved cache folder to "/wp-content/cache/bwp_gxs/"

### DIFF
--- a/includes/class-bwp-simple-gxs.php
+++ b/includes/class-bwp-simple-gxs.php
@@ -179,8 +179,15 @@ class BWP_SIMPLE_GXS extends BWP_FRAMEWORK {
 		
 		$this->cache_time = (int) $this->options['input_cache_age'] * (int) $this->options['select_time_type'];
 		$this->oldest_time = (int) $this->options['input_oldest'] * (int) $this->options['select_oldest_type'];
-		$this->options['input_cache_dir'] = plugin_dir_path($this->plugin_file) . 'cache/';
-		$this->options['input_cache_dir'] = $this->uni_path_sep($this->options['input_cache_dir']);
+
+		// Allow overriding of the cache folder via wp-config.php
+		if ( defined( 'BWP_GXS_CACHE_DIR' ) && BWP_GXS_CACHE_DIR ) {
+			$cache_dir = trailingslashit( BWP_GXS_CACHE_DIR );
+		} else {
+			// Place cache folder in /wp-content/cache/bwp_gxs/
+			$cache_dir = WP_CONTENT_DIR . 'cache/bwp_gxs/';
+		}
+		$this->options['input_cache_dir'] = $cache_dir;
 
 		$module_map = apply_filters('bwp_gxs_module_mapping', array());
 		$this->module_map = wp_parse_args($module_map, array('post_format' => 'post_tag'));


### PR DESCRIPTION
The cached content should not be in the plugins folder.
Changed cache folder to use the standard directory for caching content `/wp-content/cache/bwp_gxs/`.

The `/wp-content/` folder should have the right permissions after standard hardening of WordPress user / directory permissions, the current method of using the plugins folder does not.

This is technically incomplete as there is no code to create the folder `/wp-content/cache/bwp_gxs/`, perhaps with the exception of documenting the location of the folder and the requirement for it in the installation instructions.
Although this is no less complete when compared to the current code on "good" hosts the plugin folder will be locked down security wise and the "cache" folder will not be writeable.

Users will be warned by the checks to ensure the folder is writeable.

Also added support to override the location of the cache folder via adding a line similar to the following to `wp-config.php`:
`
define( 'BWP_GXS_CACHE_DIR', dirname( __FILE__ ) . '/wp-content/cache/my-custom-cache-folder-for-bwp-gxs/' );
`

The following actions should probably also be taken:
1. Document the cache location change.
2. Add code to create the cache folder, should probably use `WP_Filesystem` http://ottopress.com/2011/tutorial-using-the-wp_filesystem/
3. Add code to create a `.htaccess` in the new cache folder.
