### PR TITLE
bwp_gxs_post_count_where filter added

### DIFF
--- a/src/modules/sitemapindex.php
+++ b/src/modules/sitemapindex.php
@@ -73,6 +73,8 @@ class BWP_GXS_MODULE_INDEX extends BWP_GXS_MODULE
 				? ' AND p.ID NOT IN (' . implode(',', $excluded_posts) . ') '
 				: '';
 
+			$bwp_gxs_post_count_where = apply_filters( 'bwp_gxs_post_count_where', 'AND 1=1' );
+
 			// we need to split post-based sitemaps
 			$post_count_query = '
 				SELECT
@@ -81,6 +83,7 @@ class BWP_GXS_MODULE_INDEX extends BWP_GXS_MODULE
 				FROM ' . $wpdb->posts . " p
 				WHERE p.post_status = 'publish'
 					$exclude_post_sql
+					$bwp_gxs_post_count_where
 					AND p.post_password = ''" . '
 				GROUP BY p.post_type
 			';


### PR DESCRIPTION
When using `bwp_gxs_post_where` we can exclude large amount posts but sitemap calculation doesn't apply that sql conditions. So we can get empty sitemaps. 

<img width="828" alt="screen shot 2016-05-13 at 02 01 24" src="https://cloud.githubusercontent.com/assets/1421387/15233117/a48e2724-18ae-11e6-888f-c8b6f7dde1aa.png">

I think `bwp_gxs_post_count_where` filter will help to prevent these kind of situation.
