### PR TITLE
Change priority score format to non-locale aware

### DIFF
--- a/src/sitemap/sanitizer/xml/priority.php
+++ b/src/sitemap/sanitizer/xml/priority.php
@@ -23,7 +23,7 @@ class BWP_Sitemaps_Sitemap_Sanitizer_Xml_PrioritySanitizer extends BWP_Sitemaps_
 			return null;
 		}
 
-		return sprintf('%.1f', $value);
+		return sprintf('%.1F', $value);
 	}
 
 	protected function set_default_options()


### PR DESCRIPTION
Since locale settings could use comma as decimal point, ensure to use non-locale aware format for a valid tag value.